### PR TITLE
Add Timescale Toolkit 

### DIFF
--- a/TimescaleDB-PostGIS/Dockerfile.template
+++ b/TimescaleDB-PostGIS/Dockerfile.template
@@ -31,7 +31,7 @@ RUN apt-get update \
     && echo "deb https://packagecloud.io/timescale/timescaledb/debian/ $(lsb_release -c -s) main" | tee /etc/apt/sources.list.d/timescaledb.list \
     && wget --quiet -O - https://packagecloud.io/timescale/timescaledb/gpgkey | apt-key add - \
     && apt-get update \
-    && apt-get install -y "timescaledb-2-postgresql-${PG_MAJOR}" \
+    && apt-get install -y "timescaledb-2-postgresql-${PG_MAJOR}" "timescaledb-toolkit-postgresql--${PG_MAJOR}" \
     && apt-get remove -y lsb-release wget \
     && 	rm -fr /tmp/* \
     && 	rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Update Dockerfile.template to install the timescale hyperfunction toolkit - https://docs.timescale.com/self-hosted/latest/tooling/install-toolkit/#install-toolkit-on-ubuntu-and-other-debian-based-systems